### PR TITLE
fix (README): Properly recognize Fernando's Good Boy status

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ For example, training a LoRA on my dog Fernando (a very good boy) with the follo
     <img src="figures/fernando_original.jpg" width="800">
 </p>
 
-Lets me generate the following images of my dog given the prompt: 
+Lets me generate the following images of Fernando given the prompt: 
 `Cinematic photo of a dog [fernando] wearing a space suit.`
 <p align="center">
     <img src="figures/fernando.jpg" width="800">

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ information is provided in the [inference guide](inference).
 We also provide our own implementation for training and using LoRAs with Stable Cascade, which can be used to finetune 
 the text-conditional model (Stage C). Specifically, you can add and learn new tokens and add LoRA layers to the model. 
 This [notebook](inference/lora.ipynb) shows how you can use a trained LoRA. 
-For example, training a LoRA on my dog with the following kind of training images:
+For example, training a LoRA on my dog Fernando (a very good boy) with the following kind of training images:
 <p align="center">
     <img src="figures/fernando_original.jpg" width="800">
 </p>


### PR DESCRIPTION
As I was examining the `README.md`, particularly the section about LoRA training, I stumbled upon a segment that, while informative, seems to have overlooked a critical detail that I believe warrants correction.

### Current Text:
`For example, training a LoRA on my dog with the following kind of training images` [...]
`Lets me generate the following images of my dog given the prompt`

An integral component of this example seems to have been inadvertently omitted, leading to a potential miscommunication of the narrative and the role of the involved parties.

### Suggested Revision:
`For example, training a LoRA on my dog Fernando (a very good boy) with the following kind of training images` [...]
`Lets me generate the following images of Fernando given the prompt`

### Why This Correction is Imperative:
- **Upholding Character Integrity**: Ignoring Fernando's right to be recognized as a very good boy not only detracts from the quality of the documentation, but also does a disservice to Fernando himself. His character plays a pivotal role in the narrative, and omitting such a fundamental aspect undermines the integrity of his portrayal.

- **Enhancing Reader Engagement**: Acknowledging Fernando's status as a very good boy adds an element of personality to the documentation. It transforms a standard technical example into a more engaging and memorable narrative, fostering a stronger connection with the audience. This inclusion makes the technical content more relatable and enjoyable, enhancing the overall reader experience.

Warmest regards,
n0kovo