### PR TITLE
Get LoRA script to work for single gpus

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -112,7 +112,7 @@ class WarpCore(ABC):
 
     # perform the training here
     @abstractmethod
-    def train(self, data: Data, extras: Extras, models: Models, optimizers: Optimizers, schedulers: Schedulers):
+    def train(self, data: Data, extras: Extras, models: Models, optimizers: Optimizers, schedulers: Schedulers, single_gpu: bool=False):
         raise NotImplementedError("This method needs to be overriden")
     # ------------
 
@@ -357,7 +357,7 @@ class WarpCore(ABC):
         # TRAIN
         if self.is_main_node:
             print("**TRAINING STARTING...**")
-        self.train(data, extras, models, optimizers, schedulers)
+        self.train(data, extras, models, optimizers, schedulers, single_gpu)
 
         if single_gpu is False:
             barrier()

--- a/train/base.py
+++ b/train/base.py
@@ -239,7 +239,7 @@ class TrainingCore(DataCore, WarpCore):
         raise NotImplementedError("This method needs to be overriden")
 
     def train(self, data: WarpCore.Data, extras: WarpCore.Extras, models: Models, optimizers: Optimizers,
-              schedulers: WarpCore.Schedulers):
+            schedulers: WarpCore.Schedulers, single_gpu: bool=False):
         start_iter = self.info.iter + 1
         max_iters = self.config.updates * self.config.grad_accum_steps
         if self.is_main_node:
@@ -304,13 +304,14 @@ class TrainingCore(DataCore, WarpCore):
                             'bucket_ranges': extras.gdf.loss_weight.bucket_ranges.tolist(),
                             'bucket_losses': extras.gdf.loss_weight.bucket_losses.tolist(),
                         }
-                    self.save_checkpoints(models, optimizers)
+                    self.save_checkpoints(models, optimizers, single_gpu=single_gpu)
                     if self.is_main_node:
                         create_folder_if_necessary(f'{self.config.output_path}/{self.config.experiment_id}/')
                     self.sample(models, data, extras)
 
-    def save_checkpoints(self, models: Models, optimizers: Optimizers, suffix=None):
-        barrier()
+    def save_checkpoints(self, models: Models, optimizers: Optimizers, suffix=None, single_gpu=False):
+        if single_gpu:
+            barrier()
         suffix = '' if suffix is None else suffix
         self.save_info(self.info, suffix=suffix)
         models_dict = models.to_dict()

--- a/train/base.py
+++ b/train/base.py
@@ -326,7 +326,7 @@ class TrainingCore(DataCore, WarpCore):
                 self.save_optimizer(optimizer, f'{key}_optim{suffix}',
                                     fsdp_model=models_dict[key] if self.config.use_fsdp else None)
         if suffix == '' and self.info.total_steps > 1 and self.info.total_steps % self.config.backup_every == 0:
-            self.save_checkpoints(models, optimizers, suffix=f"_{self.info.total_steps // 1000}k")
+            self.save_checkpoints(models, optimizers, suffix=f"_{self.info.total_steps // 1000}k", single_gpu=single_gpu)
         torch.cuda.empty_cache()
 
     def sample(self, models: Models, data: WarpCore.Data, extras: Extras):

--- a/train/base.py
+++ b/train/base.py
@@ -310,7 +310,7 @@ class TrainingCore(DataCore, WarpCore):
                     self.sample(models, data, extras)
 
     def save_checkpoints(self, models: Models, optimizers: Optimizers, suffix=None, single_gpu=False):
-        if single_gpu:
+        if not single_gpu:
             barrier()
         suffix = '' if suffix is None else suffix
         self.save_info(self.info, suffix=suffix)

--- a/train/train_c_lora.py
+++ b/train/train_c_lora.py
@@ -320,7 +320,7 @@ class WurstCore(TrainingCore, DataCore, WarpCore):
 
 if __name__ == '__main__':
     print("Launching Script")
-    single_gpu = bool(sys.argv[2])
+    single_gpu = bool(args[2]) if len(args) > 2 else False
     warpcore = WurstCore(
         config_file_path=sys.argv[1] if len(sys.argv) > 1 else None,
         device=torch.device(int(os.environ.get("SLURM_LOCALID")) if not single_gpu else 0)

--- a/train/train_c_lora.py
+++ b/train/train_c_lora.py
@@ -320,11 +320,11 @@ class WurstCore(TrainingCore, DataCore, WarpCore):
 
 if __name__ == '__main__':
     print("Launching Script")
+    single_gpu = bool(sys.argv[2])
     warpcore = WurstCore(
         config_file_path=sys.argv[1] if len(sys.argv) > 1 else None,
-        device=torch.device(int(os.environ.get("SLURM_LOCALID")))
+        device=torch.device(int(os.environ.get("SLURM_LOCALID")) if not single_gpu else 0)
     )
     warpcore.fsdp_defaults['sharding_strategy'] = ShardingStrategy.NO_SHARD
-
     # RUN TRAINING
-    warpcore()
+    warpcore(single_gpu=single_gpu)

--- a/train/train_c_lora.py
+++ b/train/train_c_lora.py
@@ -320,7 +320,7 @@ class WurstCore(TrainingCore, DataCore, WarpCore):
 
 if __name__ == '__main__':
     print("Launching Script")
-    single_gpu = bool(args[2]) if len(args) > 2 else False
+    single_gpu = bool(sys.argv[2]) if len(sys.argv) > 2 else False
     warpcore = WurstCore(
         config_file_path=sys.argv[1] if len(sys.argv) > 1 else None,
         device=torch.device(int(os.environ.get("SLURM_LOCALID")) if not single_gpu else 0)


### PR DESCRIPTION
This is my first pull request in 7 yrs or something so apologies in advance if I do anything wrong.
Currently, train_c_lora.py does not support training with single GPUs as doing so will fail with missing environment variables or calls to `torch.distributed.barrier()` which (I think) is supposed to only work in multi-gpu environments.
(e.g.) https://github.com/Stability-AI/StableCascade/issues/28 https://github.com/Stability-AI/StableCascade/issues/17
This pull request will will make some modifications to add single gpu support.