### PR TITLE
areebjaved26:#39 change wget to wget-c

### DIFF
--- a/models/download_models.sh
+++ b/models/download_models.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+    #!/bin/bash
 
 # Check if at least two arguments were provided (excluding the optional first one)
 if [ $# -lt 2 ]; then
@@ -9,9 +9,9 @@ fi
 # Check for the optional "essential" argument and download the essential models if present
 if [ "$1" == "essential" ]; then
         echo "Downloading Essential Models (EfficientNet, Stage A, Previewer)"
-        wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_a.safetensors -P . -q --show-progress
-        wget https://huggingface.co/stabilityai/StableWurst/resolve/main/previewer.safetensors -P . -q --show-progress
-        wget https://huggingface.co/stabilityai/StableWurst/resolve/main/effnet_encoder.safetensors -P . -q --show-progress
+        wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_a.safetensors -P . -q --show-progress
+        wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/previewer.safetensors -P . -q --show-progress
+        wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/effnet_encoder.safetensors -P . -q --show-progress
     shift # Move the arguments, $2 becomes $1, $3 becomes $2, etc.
 fi
 
@@ -23,44 +23,44 @@ case $second_argument in
     big-big)
         if [ "$binary_decision" == "bfloat16" ]; then
             echo "Downloading Large Stage B & Large Stage C"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_bf16.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_bf16.safetensors -P . -q --show-progress
         else
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c.safetensors -P . -q --show-progress
         fi
         ;;
     big-small)
         if [ "$binary_decision" == "bfloat16" ]; then
             echo "Downloading Large Stage B & Small Stage C (BFloat16)"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_bf16.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite_bf16.safetensors -P . -q --show-progress
         else
             echo "Downloading Large Stage B & Small Stage C"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite.safetensors -P . -q --show-progress
         fi
         ;;
     small-big)
         if [ "$binary_decision" == "bfloat16" ]; then
             echo "Downloading Small Stage B & Large Stage C (BFloat16)"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite_bf16.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_bf16.safetensors -P . -q --show-progress
         else
             echo "Downloading Small Stage B & Large Stage C"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c.safetensors -P . -q --show-progress
         fi
         ;;
     small-small)
         if [ "$binary_decision" == "bfloat16" ]; then
             echo "Downloading Small Stage B & Small Stage C (BFloat16)"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite_bf16.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite_bf16.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite_bf16.safetensors -P . -q --show-progress
         else
             echo "Downloading Small Stage B & Small Stage C"
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite.safetensors -P . -q --show-progress
-            wget https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_b_lite.safetensors -P . -q --show-progress
+            wget-c https://huggingface.co/stabilityai/StableWurst/resolve/main/stage_c_lite.safetensors -P . -q --show-progress
         fi
         ;;
     *)


### PR DESCRIPTION
Modified the download_models.sh script in the StableCascade repository on GitHub to enhance the downloading process by using the -c flag with wget. This modification allows wget to detect if files have already been partially or fully downloaded. In case of a partial download or if the file already exists, wget will resume the download from where it left off rather than re-downloading the entire file. This change ensures a more efficient and robust downloading experience, particularly for users with unreliable internet connections or who may have partially downloaded files.

By incorporating this change, users can now benefit from reduced download times and minimized data usage, as well as avoid potential frustration caused by interrupted downloads. This enhancement contributes to a smoother workflow for individuals utilizing the StableCascade models, promoting a more seamless experience when acquiring the necessary resources for their projects or research endeavors.